### PR TITLE
Configure colors

### DIFF
--- a/markata.example.toml
+++ b/markata.example.toml
@@ -75,6 +75,7 @@ color_default_task_priority= "bright_black"
 color_default_task_date= "bright_black"
 color_focused_border= "#e8bde3"  # hex values are also allowed
 color_default_border= "#c122ac"
+color_title="#e1af66"
 
 [markata.todoui.keys]
 q="quit"

--- a/markata.example.toml
+++ b/markata.example.toml
@@ -67,15 +67,14 @@ new_post='tmux popup -d "~/git/markata-todoui-sample" copier copy ~/.copier-temp
 
 [markata.todoui.colors]
 
-color_focused_task= "#83DCC8" # hex values are allowed
-color_focused_task_priority= "purple" # color keys interpreted by rich are also allowed
-color_focused_task_date= "purple"
-color_default_task= "blue"
+color_focused_task= "red"
+color_focused_task_priority= "bright_black" # color keys interpreted by rich are also allowed
+color_focused_task_date= "bright_black"
+color_default_task= "purple"
 color_default_task_priority= "bright_black"
 color_default_task_date= "bright_black"
-color_focused_border= "#c792ea"
-color_default_border= "#484e5a"
-color_title= "white"
+color_focused_border= "#e8bde3"  # hex values are allowed
+color_default_border= "#c122ac"
 
 [markata.todoui.keys]
 q="quit"

--- a/markata.example.toml
+++ b/markata.example.toml
@@ -68,12 +68,12 @@ new_post='tmux popup -d "~/git/markata-todoui-sample" copier copy ~/.copier-temp
 [markata.todoui.colors]
 
 color_focused_task= "red"
-color_focused_task_priority= "bright_black" # color keys interpreted by rich are also allowed
+color_focused_task_priority= "bright_black" # color nterpreted by rich 
 color_focused_task_date= "bright_black"
 color_default_task= "purple"
 color_default_task_priority= "bright_black"
 color_default_task_date= "bright_black"
-color_focused_border= "#e8bde3"  # hex values are allowed
+color_focused_border= "#e8bde3"  # hex values are also allowed
 color_default_border= "#c122ac"
 
 [markata.todoui.keys]

--- a/markata.example.toml
+++ b/markata.example.toml
@@ -65,6 +65,18 @@ editor='kitty nvim {file}'
 # set new post to call copier template in a tmux popup
 new_post='tmux popup -d "~/git/markata-todoui-sample" copier copy ~/.copier-templates/todo ~/git/markata-todoui-sample/'
 
+[markata.todoui.colors]
+
+color_focused_task= "#83DCC8" # hex values are allowed
+color_focused_task_priority= "purple" # color keys interpreted by rich are also allowed
+color_focused_task_date= "purple"
+color_default_task= "blue"
+color_default_task_priority= "bright_black"
+color_default_task_date= "bright_black"
+color_focused_border= "#c792ea"
+color_default_border= "#484e5a"
+color_title= "white"
+
 [markata.todoui.keys]
 q="quit"
 l="next_stack"

--- a/markata_todoui/__init__.py
+++ b/markata_todoui/__init__.py
@@ -18,7 +18,7 @@ from textual.widgets import Footer
 
 from markata_todoui.posts import Posts
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 
 
 DEFAULT_KEYS = {

--- a/markata_todoui/__init__.py
+++ b/markata_todoui/__init__.py
@@ -18,7 +18,7 @@ from textual.widgets import Footer
 
 from markata_todoui.posts import Posts
 
-__version__ = "0.0.1"
+__version__ = "0.0.3"
 
 
 DEFAULT_KEYS = {

--- a/markata_todoui/posts.py
+++ b/markata_todoui/posts.py
@@ -107,12 +107,12 @@ class Posts(Widget):
                     f"[{self.colors['color_default_task_date']}]{post.get('date')}[/]",
                 )
         if self.is_selected:
-            self.border_style = "#e8bde3"
+            self.border_style = f"{self.colors['color_focused_border']}"
         else:
-            self.border_style = "#c122ac"
+            self.border_style = f"{self.colors['color_default_border']}"
         return Panel(
             grid,
-            title=f"[#e1af66]{self.title} ({len(self.post_list)})",
+            title=f"[{self.colors['color_title']}]{self.title} ({len(self.post_list)})",
             border_style=self.border_style,
         )
 

--- a/markata_todoui/posts.py
+++ b/markata_todoui/posts.py
@@ -20,6 +20,7 @@ DEFAULT_COLORS = {
     "color_default_task_date": "bright_black",
     "color_focused_border": "#e8bde3",
     "color_default_border": "#c122ac",
+    "color_title": "#e1af66",
 }
 
 

--- a/markata_todoui/posts.py
+++ b/markata_todoui/posts.py
@@ -87,7 +87,7 @@ class Posts(Widget):
                 and self.is_selected
             ):
                 grid.add_row(
-                    f"[red]{post.get('title')}",
+                    f"[{self.config.get('color_focused_task', 'red')}]{post.get('title')}",
                     f"[bright_black]({post.get('priority')})[/]",
                     f"[bright_black]{post.get('date')}[/]",
                 )

--- a/markata_todoui/posts.py
+++ b/markata_todoui/posts.py
@@ -18,6 +18,8 @@ DEFAULT_COLORS = {
     "color_default_task": "purple",
     "color_default_task_priority": "bright_black",
     "color_default_task_date": "bright_black",
+    "color_focused_border": "#e8bde3",
+    "color_default_border": "#c122ac",
 }
 
 

--- a/markata_todoui/posts.py
+++ b/markata_todoui/posts.py
@@ -11,6 +11,14 @@ from rich.table import Table
 from textual.widget import Widget
 
 DEFAULT_EDITOR = "vi {file}"
+DEFAULT_COLORS = {
+    "color_focused_task": "red",
+    "color_focused_task_priority": "bright_black",
+    "color_focused_task_date": "bright_black",
+    "color_default_task": "purple",
+    "color_default_task_priority": "bright_black",
+    "color_default_task_date": "bright_black",
+}
 
 
 class DummyPost(frontmatter.Post):
@@ -46,6 +54,7 @@ class Posts(Widget):
         super().__init__(title)
         self.m = markata
         self.config = self.m.get_plugin_config("todoui") or {}
+        self.colors = self.config.get("colors", DEFAULT_COLORS)
 
         self.title = title
         self.name = title
@@ -87,15 +96,15 @@ class Posts(Widget):
                 and self.is_selected
             ):
                 grid.add_row(
-                    f"[{self.config.get('color_focused_task', 'red')}]{post.get('title')}",
-                    f"[bright_black]({post.get('priority')})[/]",
-                    f"[bright_black]{post.get('date')}[/]",
+                    f"[{self.colors['color_focused_task']}]{post.get('title')}",
+                    f"[{self.colors['color_focused_task_priority']}]({post.get('priority')})[/]",
+                    f"[{self.colors['color_focused_task_date']}]{post.get('date')}[/]",
                 )
             else:
                 grid.add_row(
-                    f"[purple]{post.get('title')}",
-                    f"[bright_black]({post.get('priority')})[/]",
-                    f"[bright_black]{post.get('date')}[/]",
+                    f"[{self.colors['color_default_task']}]{post.get('title')}",
+                    f"[{self.colors['color_default_task_priority']}]({post.get('priority')})[/]",
+                    f"[{self.colors['color_default_task_date']}]{post.get('date')}[/]",
                 )
         if self.is_selected:
             self.border_style = "#e8bde3"

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ with open("requirements_dev.txt", "r", encoding="utf-8") as f:
 
 setup(
     name=NAME,
-    version="0.0.3",
+    version="0.0.4",
     description="A todo plugin for markta",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# Purpose

Give a user the ability to customize some of the colors of the todoui.
Users may be used to a different set of color queues, this allows them to incorporate that into the todoui

# Implementation

Add a `markata.todoui.colors` section in `markata.toml`

```toml
[markata.todoui.colors]

color_focused_task= "#83DCC8"
color_focused_task_priority= "purple"
color_focused_task_date= "purple"
color_default_task= "blue"
color_default_task_priority= "bright_black"
color_default_task_date= "bright_black"
color_focused_border= "#c792ea"
color_default_border= "#484e5a"
color_title= "white"

```